### PR TITLE
Tiled 0.15.2

### DIFF
--- a/tiled.nuspec
+++ b/tiled.nuspec
@@ -3,7 +3,7 @@
 	<metadata>
 		<id>tiled</id>
 		<title>Tiled Map Editor</title>
-		<version>0.15.0</version>
+		<version>0.15.2</version>
 		<authors>Thorbjørn Lindeijer</authors>
 		<owners>Adrián Arroyo</owners>
 		<summary>tiled</summary>

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,4 +1,4 @@
-$url = "https://github.com/bjorn/tiled/releases/download/v0.15.0/tiled-0.15.0-win32-setup.exe"
-$url64 = "https://github.com/bjorn/tiled/releases/download/v0.15.0/tiled-0.15.0-win64-setup.exe"
+$url = "https://github.com/bjorn/tiled/releases/download/v0.15.2/tiled-0.15.2-win32-setup.exe"
+$url64 = "https://github.com/bjorn/tiled/releases/download/v0.15.2/tiled-0.15.2-win64-setup.exe"
 
 Install-ChocolateyPackage "tiled" "exe" "/S" "$url" "$url64"


### PR DESCRIPTION
Actually the latest version of Tiled is 0.16.2, but this will require adjusting the installation command to work with the new MSI installer.

Do I understand correctly that deploying the new version to chocolatey.org will be automatic from AppVeyor?
