### PR TITLE
Upgraded to v1.3.1 (x86 no longer supported).

### DIFF
--- a/tiled.nuspec
+++ b/tiled.nuspec
@@ -3,7 +3,7 @@
 	<metadata>
 		<id>tiled</id>
 		<title>Tiled Map Editor</title>
-		<version>0.16.2.20160712</version>
+		<version>1.3.1</version>
 		<authors>Thorbjørn Lindeijer</authors>
 		<owners>Adrián Arroyo</owners>
 		<summary>tiled</summary>

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,4 +1,3 @@
-$url = "https://github.com/bjorn/tiled/releases/download/v0.16.2/tiled-0.16.2-win32.msi"
-$url64 = "https://github.com/bjorn/tiled/releases/download/v0.16.2/tiled-0.16.2-win64.msi"
+$url64 = "https://github.com/bjorn/tiled/releases/download/v1.3.1/Tiled-1.3.1-win64.msi"
 
-Install-ChocolateyPackage "tiled" "msi" "/quiet" "$url" "$url64" -validExitCodes @(0,3010)
+Install-ChocolateyPackage -PackageName "tiled" -FileType "msi" -SilentArgs "/quiet" -Url64bit "$url64" -validExitCodes @(0,3010)


### PR DESCRIPTION
Updated x64 installer references to v1.3.1 and removed x86 installer reference as it no longer seems to have been supported by Bjorn since v1.2.6.